### PR TITLE
Add argument parsing and CLI mode

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -7,4 +7,4 @@ FROM openjdk:17
 EXPOSE 8080:8080
 RUN mkdir /app
 COPY --from=build /home/gradle/src/build/libs/couch-tracker-server.jar /app/couch-tracker-server.jar
-ENTRYPOINT ["java","-jar","/app/couch-tracker-server.jar"]
+ENTRYPOINT ["java", "-jar", "/app/couch-tracker-server.jar", "start" , "--all"]

--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -6,8 +6,8 @@ plugins {
     kotlin("jvm") version "1.8.10"
     kotlin("plugin.serialization") version "1.8.10"
     id("io.gitlab.arturbosch.detekt").version("1.22.0")
-    id("io.ktor.plugin") version "2.2.3"
-    id("com.github.ben-manes.versions") version "0.45.0"
+    id("io.ktor.plugin") version "2.2.4"
+    id("com.github.ben-manes.versions") version "0.46.0"
     application
 }
 
@@ -26,10 +26,10 @@ dependencies {
 
     // Utilities
     implementation("org.jetbrains.kotlinx:kotlinx-datetime:0.4.0")
-    implementation("org.jetbrains.kotlinx:kotlinx-serialization-json:1.4.1")
+    implementation("org.jetbrains.kotlinx:kotlinx-serialization-json:1.5.0")
 
     // Ktor
-    val ktorVersion = "2.2.3"
+    val ktorVersion = "2.2.4"
     implementation("io.ktor:ktor-server-core:$ktorVersion")
     implementation("io.ktor:ktor-server-netty:$ktorVersion")
     implementation("io.ktor:ktor-server-call-logging:$ktorVersion")
@@ -44,7 +44,7 @@ dependencies {
     implementation("io.ktor:ktor-server-auth-jwt:$ktorVersion")
 
     // Logs
-    implementation("ch.qos.logback:logback-classic:1.4.5")
+    implementation("ch.qos.logback:logback-classic:1.4.6")
     implementation("io.github.microutils:kotlin-logging-jvm:3.0.5")
 
     // Mongo
@@ -55,7 +55,7 @@ dependencies {
     implementation("com.uwetrottmann.tmdb2:tmdb-java:2.8.1")
 
     // Configuration parsing
-    val hopliteVersion = "2.7.1"
+    val hopliteVersion = "2.7.3"
     implementation("com.sksamuel.hoplite:hoplite-core:$hopliteVersion")
     implementation("com.sksamuel.hoplite:hoplite-toml:$hopliteVersion")
 

--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -60,6 +60,7 @@ dependencies {
     implementation("com.sksamuel.hoplite:hoplite-toml:$hopliteVersion")
 
     // Other
+    implementation("com.github.ajalt.clikt:clikt:3.5.2")
     implementation("de.mkammerer:argon2-jvm:2.11")
 
     // TEST DEPENDENCIES

--- a/src/main/kotlin/com/github/couchtracker/server/HttpServer.kt
+++ b/src/main/kotlin/com/github/couchtracker/server/HttpServer.kt
@@ -1,0 +1,89 @@
+package com.github.couchtracker.server
+
+import ch.qos.logback.classic.Logger
+import com.github.ajalt.clikt.core.CliktCommand
+import com.github.couchtracker.server.config.Config
+import com.github.couchtracker.server.routes.authRoutes
+import com.github.couchtracker.server.routes.showRoutes
+import com.github.couchtracker.server.routes.users.users
+import com.github.couchtracker.server.util.serializers.LocaleSerializer
+import com.github.couchtracker.server.util.serializers.convertWithSerializer
+import io.ktor.serialization.kotlinx.json.json
+import io.ktor.server.application.Application
+import io.ktor.server.application.call
+import io.ktor.server.application.install
+import io.ktor.server.auth.Authentication
+import io.ktor.server.auth.authenticate
+import io.ktor.server.engine.embeddedServer
+import io.ktor.server.netty.Netty
+import io.ktor.server.plugins.callloging.CallLogging
+import io.ktor.server.plugins.compression.Compression
+import io.ktor.server.plugins.compression.condition
+import io.ktor.server.plugins.compression.gzip
+import io.ktor.server.plugins.contentnegotiation.ContentNegotiation
+import io.ktor.server.plugins.dataconversion.DataConversion
+import io.ktor.server.plugins.requestvalidation.RequestValidation
+import io.ktor.server.plugins.statuspages.StatusPages
+import io.ktor.server.request.uri
+import io.ktor.server.resources.Resources
+import io.ktor.server.response.respond
+import io.ktor.server.routing.get
+import io.ktor.server.routing.route
+import io.ktor.server.routing.routing
+import org.slf4j.LoggerFactory
+import kotlinx.coroutines.runBlocking
+
+object HttpServer : CliktCommand(help = "Start the HTTP server") {
+
+    override fun run() {
+        val config = Config.load()
+        (LoggerFactory.getLogger(org.slf4j.Logger.ROOT_LOGGER_NAME) as Logger).level = config.logLevel.level
+
+        logger.info { "Starting HTTP server component" }
+        embeddedServer(
+            Netty,
+            port = config.port,
+            host = config.host,
+            module = { couchTrackerModule(config) },
+        ).start(wait = true)
+    }
+
+    private fun Application.couchTrackerModule(config: Config) {
+        val applicationData = runBlocking { ApplicationData.create(this@couchTrackerModule, config) }
+
+        install(CallLogging)
+        install(DataConversion) {
+            convertWithSerializer(LocaleSerializer)
+        }
+        install(Compression) {
+            gzip {
+                // Disable for sensitive APIs. See https://en.wikipedia.org/wiki/BREACH
+                condition { !request.uri.startsWith("/api/auth") }
+            }
+        }
+        install(ContentNegotiation) { json() }
+        install(RequestValidation)
+        install(Authentication) {
+            JWT.Login.install(this, applicationData)
+        }
+        install(StatusPages) {
+            exception<IgnoreException> { _, _ -> }
+        }
+        install(Resources)
+
+        routing {
+            route("/api") {
+                get {
+                    call.respond(applicationData.apiInfo)
+                }
+                authRoutes(applicationData)
+                authenticate(JWT.Login.ACCESS) {
+                    showRoutes(applicationData)
+                    users(applicationData)
+                }
+            }
+        }
+    }
+}
+
+class IgnoreException : RuntimeException()

--- a/src/main/kotlin/com/github/couchtracker/server/Main.kt
+++ b/src/main/kotlin/com/github/couchtracker/server/Main.kt
@@ -1,85 +1,18 @@
 package com.github.couchtracker.server
 
-import ch.qos.logback.classic.Logger
-import com.github.couchtracker.server.config.Config
-import com.github.couchtracker.server.routes.authRoutes
-import com.github.couchtracker.server.routes.showRoutes
-import com.github.couchtracker.server.routes.users.users
-import com.github.couchtracker.server.util.serializers.LocaleSerializer
-import com.github.couchtracker.server.util.serializers.convertWithSerializer
-import io.ktor.serialization.kotlinx.json.json
-import io.ktor.server.application.Application
-import io.ktor.server.application.call
-import io.ktor.server.application.install
-import io.ktor.server.auth.Authentication
-import io.ktor.server.auth.authenticate
-import io.ktor.server.engine.embeddedServer
-import io.ktor.server.netty.Netty
-import io.ktor.server.plugins.callloging.CallLogging
-import io.ktor.server.plugins.compression.Compression
-import io.ktor.server.plugins.compression.condition
-import io.ktor.server.plugins.compression.gzip
-import io.ktor.server.plugins.contentnegotiation.ContentNegotiation
-import io.ktor.server.plugins.dataconversion.DataConversion
-import io.ktor.server.plugins.requestvalidation.RequestValidation
-import io.ktor.server.plugins.statuspages.StatusPages
-import io.ktor.server.request.uri
-import io.ktor.server.resources.Resources
-import io.ktor.server.response.respond
-import io.ktor.server.routing.get
-import io.ktor.server.routing.route
-import io.ktor.server.routing.routing
-import org.slf4j.LoggerFactory
-import kotlinx.coroutines.runBlocking
+import com.github.ajalt.clikt.core.NoOpCliktCommand
+import com.github.ajalt.clikt.core.subcommands
+import com.github.couchtracker.server.cli.Cli
+import mu.KotlinLogging
 
-fun main() {
-    val config = Config.load()
-    // TODO log level is set too late, so some logs are always printed no matter the logLevel
-    (LoggerFactory.getLogger(org.slf4j.Logger.ROOT_LOGGER_NAME) as Logger).level = config.logLevel.level
+val logger = KotlinLogging.logger { }
 
-    embeddedServer(
-        Netty,
-        port = config.port,
-        host = config.host,
-        module = { couchTrackerModule(config) },
-    ).start(wait = true)
-}
+object Main : NoOpCliktCommand(printHelpOnEmptyArgs = true) {
 
-fun Application.couchTrackerModule(config: Config) {
-    val applicationData = runBlocking { ApplicationData.create(this@couchTrackerModule, config) }
-
-    install(CallLogging)
-    install(DataConversion) {
-        convertWithSerializer(LocaleSerializer)
-    }
-    install(Compression) {
-        gzip {
-            // Disable for sensitive APIs. See https://en.wikipedia.org/wiki/BREACH
-            condition { !request.uri.startsWith("/api/auth") }
-        }
-    }
-    install(ContentNegotiation) { json() }
-    install(RequestValidation)
-    install(Authentication) {
-        JWT.Login.install(this, applicationData)
-    }
-    install(StatusPages) {
-        exception<IgnoreException> { _, _ -> }
-    }
-    install(Resources)
-
-    routing {
-        route("/api") {
-            get {
-                call.respond(applicationData.apiInfo)
-            }
-            authRoutes(applicationData)
-            authenticate(JWT.Login.ACCESS) {
-                showRoutes(applicationData)
-                users(applicationData)
-            }
-        }
+    init {
+        subcommands(Start)
+        subcommands(Cli)
     }
 }
 
-class IgnoreException : RuntimeException()
+fun main(args: Array<String>) = Main.main(args)

--- a/src/main/kotlin/com/github/couchtracker/server/Start.kt
+++ b/src/main/kotlin/com/github/couchtracker/server/Start.kt
@@ -1,0 +1,40 @@
+package com.github.couchtracker.server
+
+import com.github.ajalt.clikt.core.CliktCommand
+import com.github.ajalt.clikt.core.UsageError
+import com.github.ajalt.clikt.core.subcommands
+import com.github.ajalt.clikt.parameters.options.flag
+import com.github.ajalt.clikt.parameters.options.option
+
+object Start : CliktCommand(
+    help = """
+        Start one or more components of the app
+        
+        You can either specify --all to start all the components, or pass the components you want to run separated by a space.
+        
+        Example: couch-tracker-server start component1 component2
+    """.trimIndent(),
+    allowMultipleSubcommands = true,
+    invokeWithoutSubcommand = true,
+    printHelpOnEmptyArgs = true,
+) {
+
+    private val subcommands = listOf(HttpServer)
+
+    init {
+        subcommands(subcommands)
+    }
+
+    private val all by option("--all", help = "Starts all components").flag(default = false)
+
+    override fun run() {
+        if (all) {
+            if (currentContext.invokedSubcommand != null) {
+                throw UsageError("You can either pass --all or a list of components, but not both")
+            }
+            subcommands.forEach {
+                it.run()
+            }
+        }
+    }
+}

--- a/src/main/kotlin/com/github/couchtracker/server/cli/Cli.kt
+++ b/src/main/kotlin/com/github/couchtracker/server/cli/Cli.kt
@@ -1,0 +1,41 @@
+package com.github.couchtracker.server.cli
+
+import ch.qos.logback.classic.Level
+import ch.qos.logback.classic.Logger
+import com.github.ajalt.clikt.core.NoOpCliktCommand
+import com.github.ajalt.clikt.core.subcommands
+import com.github.ajalt.clikt.parameters.options.OptionTransformContext
+import com.github.couchtracker.server.ApplicationData
+import com.github.couchtracker.server.cli.users.Users
+import com.github.couchtracker.server.config.Config
+import com.github.couchtracker.server.util.ValidationResult
+import org.slf4j.LoggerFactory
+import kotlinx.coroutines.CoroutineScope
+import kotlinx.coroutines.runBlocking
+
+object Cli : NoOpCliktCommand(
+    help = "CLI to perform some administrative actions",
+    printHelpOnEmptyArgs = true,
+    invokeWithoutSubcommand = true,
+) {
+
+    init {
+        subcommands(Users)
+    }
+}
+
+fun runBlockingCli(block: suspend CoroutineScope.(ApplicationData) -> Unit) = runBlocking {
+    val config = Config.load()
+    // For CLI commands, we don't want the logs
+    (LoggerFactory.getLogger(org.slf4j.Logger.ROOT_LOGGER_NAME) as Logger).level = Level.OFF
+
+    val ad = ApplicationData.create(this, config)
+    block(ad)
+}
+
+fun ValidationResult.failOnError(context: OptionTransformContext) {
+    when (this) {
+        is ValidationResult.Error -> context.fail(this.message)
+        is ValidationResult.Success -> Unit
+    }
+}

--- a/src/main/kotlin/com/github/couchtracker/server/cli/users/Add.kt
+++ b/src/main/kotlin/com/github/couchtracker/server/cli/users/Add.kt
@@ -1,0 +1,41 @@
+package com.github.couchtracker.server.cli.users
+
+import com.github.ajalt.clikt.core.CliktCommand
+import com.github.ajalt.clikt.core.PrintCompletionMessage
+import com.github.ajalt.clikt.core.PrintMessage
+import com.github.ajalt.clikt.parameters.options.convert
+import com.github.ajalt.clikt.parameters.options.option
+import com.github.ajalt.clikt.parameters.options.prompt
+import com.github.ajalt.clikt.parameters.options.validate
+import com.github.couchtracker.server.cli.failOnError
+import com.github.couchtracker.server.cli.runBlockingCli
+import com.github.couchtracker.server.model.db.UserDbo
+import com.github.couchtracker.server.util.Email
+import com.github.couchtracker.server.util.Password
+import com.github.couchtracker.server.util.Username
+
+object Add : CliktCommand(help = "Add a new user") {
+
+    private val email by option(help = "Email of the user").convert { Email(it) }.prompt()
+    private val username by option(help = "Username of the user").convert { Username(it) }.prompt()
+    private val password by option(help = "Password for the user")
+        .convert { Password(it) }
+        .prompt(hideInput = true, requireConfirmation = true)
+        .validate { it.validate().failOnError(this) }
+    private val name by option(help = "Name of the user").prompt(default = "")
+
+    override fun run() = runBlockingCli { ad ->
+        val inserted = UserDbo.insert(
+            applicationData = ad,
+            email = email,
+            username = username,
+            password = password,
+            name = name,
+        )
+        if (inserted) {
+            throw PrintCompletionMessage("User has been created", false)
+        } else {
+            throw PrintMessage("User with same email or username already exists", true)
+        }
+    }
+}

--- a/src/main/kotlin/com/github/couchtracker/server/cli/users/Users.kt
+++ b/src/main/kotlin/com/github/couchtracker/server/cli/users/Users.kt
@@ -1,0 +1,11 @@
+package com.github.couchtracker.server.cli.users
+
+import com.github.ajalt.clikt.core.NoOpCliktCommand
+import com.github.ajalt.clikt.core.subcommands
+
+object Users : NoOpCliktCommand(help = "Manage users", printHelpOnEmptyArgs = true) {
+
+    init {
+        subcommands(Add)
+    }
+}

--- a/src/main/kotlin/com/github/couchtracker/server/config/Config.kt
+++ b/src/main/kotlin/com/github/couchtracker/server/config/Config.kt
@@ -3,9 +3,6 @@ package com.github.couchtracker.server.config
 import com.sksamuel.hoplite.ConfigLoaderBuilder
 import com.sksamuel.hoplite.addFileSource
 import com.sksamuel.hoplite.sources.EnvironmentVariablesPropertySource
-import mu.KotlinLogging
-
-private val logger = KotlinLogging.logger { }
 
 data class Config(
     val logLevel: LogLevel = LogLevel.INFO,
@@ -20,7 +17,6 @@ data class Config(
 
     companion object {
         fun load(): Config {
-            logger.info { "Loading config..." }
             return ConfigLoaderBuilder
                 .default()
                 .addPropertySource(
@@ -35,8 +31,7 @@ data class Config(
                 .addFileSource("couch-tracker-dev-config.local.toml", optional = true, allowEmpty = true)
                 .addFileSource("couch-tracker-dev-config.toml", optional = true, allowEmpty = true)
                 .build()
-                .loadConfigOrThrow<Config>()
-                .also { logger.info { "Detected configuration: $it" } }
+                .loadConfigOrThrow()
         }
     }
 }

--- a/src/main/kotlin/com/github/couchtracker/server/util/Email.kt
+++ b/src/main/kotlin/com/github/couchtracker/server/util/Email.kt
@@ -9,7 +9,7 @@ private const val MIN_LENGTH = 3
 value class Email(val value: String) {
 
     init {
-        require(value.length > MIN_LENGTH) { "Email must have at least 3 characters" }
+        require(value.length >= MIN_LENGTH) { "Email must have at least 3 characters" }
         require('@' in value) { "Email must contain @ sign" }
     }
 }


### PR DESCRIPTION
With this commit the app as a whole is a CLI. The "start" subcommand provides a way to start the various components of the app (for now there's just an "http-server" component, but there will be more in the future). The "cli" subcommand will allow for some management tasks to be performed (e.g. creating users, resetting password, etc.).

With this commit the "cli add user" subcommand has also been added, which allows to create a new user. Options can be passed either via CLI arguments or via an interactive mode if not provided.